### PR TITLE
Use current dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
 		</developer>
 	</developers>
 	<properties>
-        <spring.version>4.1.6.RELEASE</spring.version>
+        <spring.version>5.1.7.RELEASE</spring.version>
+        <!--spring.version>4.1.6.RELEASE</spring.version-->
     </properties>
 	<distributionManagement>
 		  <repository>
@@ -35,27 +36,88 @@
 		     <name>OSS Snapshots</name>
 		     <url>https://oss.sonatype.org/content/repositories/snapshots</url>
 		  </snapshotRepository>
-	</distributionManagement> 
+	</distributionManagement>
 	<scm>
     	<developerConnection>scm:git:https://github.com/sammartens1234/automator-maven-plugin.git</developerConnection>
   	  <tag>HEAD</tag>
   </scm>
-  	<dependencies>
-    	<dependency>
-      		<groupId>org.apache.maven</groupId>
-      		<artifactId>maven-plugin-api</artifactId>
-      		<version>3.0</version>
-    	</dependency>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-component-annotations</artifactId>
+				<version>1.5.5</version>
+			</dependency>
+			<dependency>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-container-default</artifactId>
+				<version>1.0-alpha-30</version>
+			</dependency>
+			<dependency>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-utils</artifactId>
+				<version>3.2.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-artifact</artifactId>
+				<version>3.6.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-plugin-api</artifactId>
+				<version>3.6.1</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-digester</groupId>
+				<artifactId>commons-digester</artifactId>
+				<version>1.8</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.doxia</groupId>
+				<version>1.0</version>
+				<artifactId>doxia-sink-api</artifactId>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-model</artifactId>
+				<version>3.0</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-collections</groupId>
+				<artifactId>commons-collections</artifactId>
+				<version>3.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.velocity</groupId>
+				<artifactId>velocity</artifactId>
+				<version>1.6.2</version>
+			</dependency>
+			<dependency>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-classworlds</artifactId>
+				<version>2.2.3</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-logging</groupId>
+				<artifactId>commons-logging</artifactId>
+				<version>1.1.1</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
+
+	<dependencies>
 		<dependency>
 		    <groupId>org.apache.maven.reporting</groupId>
 		    <artifactId>maven-reporting-impl</artifactId>
-		    <version>2.4</version>
+		    <version>3.0.0</version>
 		</dependency>
  	    <!-- dependencies to annotations -->
     	<dependency>
       		<groupId>org.apache.maven.plugin-tools</groupId>
       		<artifactId>maven-plugin-annotations</artifactId>
-      		<version>3.4</version>
+      		<version>3.6.0</version>
       		<scope>provided</scope>
     	</dependency>
     	<dependency>
@@ -66,9 +128,20 @@
     	<dependency>
 		    <groupId>com.fasterxml.jackson.core</groupId>
 		    <artifactId>jackson-databind</artifactId>
-		    <version>2.7.5</version>
+		    <version>2.9.9</version>
 		</dependency>
-		<!-- 
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>2.3.1</version>
+		</dependency>
+		<dependency>
+		    <groupId>org.glassfish.jaxb</groupId>
+		    <artifactId>jaxb-runtime</artifactId>
+		    <version>2.3.2</version>
+		    <scope>runtime</scope>
+		</dependency>
+		<!--
 		<dependency>
 			  <groupId>com.jamosolutions</groupId>
 			  <artifactId>jamoautomation</artifactId>
@@ -76,24 +149,52 @@
 			  <classifier>domain</classifier>
 		</dependency>
 		-->
-		
+
   	</dependencies>
   	<build>
 	  	<plugins>
 	  		<plugin>
 	        	<groupId>org.apache.maven.plugins</groupId>
-	            <version>3.1</version>
+	            <version>3.8.1</version>
 	            <artifactId>maven-compiler-plugin</artifactId>
 	            <configuration>
-	            	<source>1.7</source>
-	                <target>1.7</target>
+	            	<source>8</source>
+	                <target>8</target>
 				</configuration>
 	        </plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-plugin-plugin</artifactId>
+				<version>3.6.0</version>
+				<configuration>
+					<mojoDependencies>
+						<param>c.c.h:plugin</param>
+					</mojoDependencies>
+				</configuration>
+			</plugin>
 	        <plugin>
 		        <groupId>org.apache.maven.plugins</groupId>
 		        <artifactId>maven-release-plugin</artifactId>
-		        <version>2.5.3</version>
-		    </plugin>
-	    </plugins>
+				<version>2.5.3</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0-M2</version>
+				<executions>
+					<execution>
+						<id>enforce</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<rules>
+						<dependencyConvergence/>
+					</rules>
+				</configuration>
+			</plugin>
+		</plugins>
 	</build>
 </project>


### PR DESCRIPTION
While trying to make jenkins integration according [your video](https://www.jamosolutions.com/single-post/2017/06/14/Integrate-with-Jenkins) work, I have encountered some minor problems. I will try to make pull requests for them.

Upgraded all dependencies to current.
Added maven enforcer plugin to make using transitive libraries a bit
less messy. This means also to name all conflicting dependencies
exact versions in dependencyManagement part.
Make maven search for mojo annotations only in project
(maven-plugi-plugin). It makes array index out of bounds go away while
packaging plugin.
Use java 8 instead of java 7 which is nearly end of life now. Plugin
is able to compile with java 11 (next LTS version) also.